### PR TITLE
Fix default hints

### DIFF
--- a/lib/src/feedback.dart
+++ b/lib/src/feedback.dart
@@ -11,8 +11,8 @@ class feedback {
   static Feedback default_feedback = Feedback()
     ..warning = ''
     ..suggestions = [
-      "Use a few words, avoid common phrases"
-          "No need for symbols, digits, or uppercase letters"
+      "Use a few words, avoid common phrases",
+      "No need for symbols, digits, or uppercase letters"
     ];
 
   static Feedback get_feedback(score, List<PasswordMatch> sequence) {


### PR DESCRIPTION
The separating commas of a CoffeeScript list are optional, which meant that our default suggestions were a single string, instead of a list with 2 elements. It was valid Dart code because dart concatenates the two strings together.